### PR TITLE
Support Themisto v2.0.0 and newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,14 @@ To run the binning + assembly pipeline, you will need a program that
 does pseudoalignment and another program that estimates an assignment
 probability matrix for the reads to the alignment targets.
 
+*Note:* This version and the previous versions of mGEMS assume that
+you are using a Themisto version between v0.1.1 and v1.2.0. Update
+your mGEMS installation for compatibility with newer versions of
+Themisto.
+
 We recommend to use [Themisto](https://github.com/algbio/themisto)
-(v0.1.1 or newer) for pseudoalignment and
+(versions between v0.1.1 or v1.2.0, update mGEMS for compatibility
+with newer versions) for pseudoalignment and
 [mSWEEP](https://github.com/probic/mSWEEP) (v1.3.2 or newer) for
 estimating the probability matrix. For assembling the bins output by
 mGEMS, we recommend [shovill](https://github.com/tseemann/shovill) for
@@ -81,6 +87,7 @@ tree presented in Mäklin et al. 2020 using mGEMS is available in the
 [docs folder of this repository](docs/TUTORIAL.md).
 
 ### Quickstart — full pipeline
+*Themisto versions v0.1.1 to v1.2.0*
 Build a [Themisto](https://github.com/algbio/themisto) index to
 align against.
 ```

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ reads_1.fastq.gz,reads_2.fastq.gz -o mGEMS-out
 mGEMS accepts the following input flags
 ```
 	-r                       Comma-separated list of input read(s).
+	-i                       Group identifiers file used with the mSWEEP call.
 	--themisto-alns          Comma-separated list of pseudoalignment file(s) 
 	                         for the reads from themisto.
 	-o                       Output directory (must exist before running!).

--- a/README.md
+++ b/README.md
@@ -87,8 +87,17 @@ tree presented in Mäklin et al. 2020 using mGEMS is available in the
 [docs folder of this repository](docs/TUTORIAL.md).
 
 ### Quickstart — full pipeline
+#### Index the reference sequences
 Build a [Themisto](https://github.com/algbio/themisto) index to
 align against.
+
+__Themisto version v2.0.0 or newer__
+
+```
+mkdir themisto_index
+mkdir themisto_index/tmp
+themisto build -k 31 -i example.fasta -o themisto_index/index --temp-dir themisto_index/tmp
+```
 
 __Themisto versions v0.1.1 to v1.2.0__
 
@@ -98,7 +107,15 @@ mkdir themisto_index/tmp
 build_index --k 31 --input-file example.fasta --auto-colors --index-dir themisto_index --temp-dir themisto_index/tmp
 ```
 
+#### Pseudoalign the reads
 Align paired-end reads 'reads_1.fastq.gz' and 'reads_2.fastq.gz' with Themisto (note the **--sort-output** flag must be used!)
+
+__Themisto version v2.0.0 or newer__
+
+```
+themisto pseudoalign -q reads_1.fastq.gz -o pseudoalignments_1.aln -i themisto_index/index --temp-dir themisto_index/tmp --rc --n-threads 16 --sort-output --gzip-output
+themisto pseudoalign -q reads_2.fastq.gz -o pseudoalignments_2.aln -i themisto_index/index --temp-dir themisto_index/tmp --rc --n-threads 16 --sort-output --gzip-output
+```
 
 __Themisto versions v0.1.1 to v1.2.0__
 
@@ -117,7 +134,7 @@ mSWEEP --themisto-1 pseudoalignments_1.aln.gz --themisto-2 pseudoalignments_2.al
 Bin the reads and write all bins to the 'mGEMS-out' folder
 ```
 mkdir mGEMS-out
-mGEMS -r reads_1.fastq.gz,reads_2.fastq.gz --themisto-alns pseudoalignments_1.aln.gz,pseudoalignments_2.aln.gz -o mGEMS-out --probs mSWEEP_probs.csv -a mSWEEP_abundances.txt --index themisto_index
+mGEMS -r reads_1.fastq.gz,reads_2.fastq.gz -i reference_grouping.txt --themisto-alns pseudoalignments_1.aln.gz,pseudoalignments_2.aln.gz -o mGEMS-out --probs mSWEEP_probs.csv -a mSWEEP_abundances.txt --index themisto_index
 ```
 This will write the binned paired-end reads for *all groups* in the
 mSWEEP_abundances.txt file in the mGEMS-out folder (compressed with
@@ -128,25 +145,25 @@ You can also extract the read-to-group assignments table that mGEMS
 uses internally by adding the `--write-assignment-table` toggle to the
 call to `mGEMS` or `mGEMS bin`:
 ```
-mGEMS --groups group-3,group-4 -r reads_1.fastq.gz,reads_2.fastq.gz --themisto-alns pseudoalignments_1.aln.gz,pseudoalignments_2.aln.gz -o mGEMS-out --probs mSWEEP_probs.csv -a mSWEEP_abundances.txt --index themisto_index --write-assignment-table
+mGEMS --groups group-3,group-4 -r reads_1.fastq.gz,reads_2.fastq.gz -i reference_grouping.txt --themisto-alns pseudoalignments_1.aln.gz,pseudoalignments_2.aln.gz -o mGEMS-out --probs mSWEEP_probs.csv -a mSWEEP_abundances.txt --index themisto_index --write-assignment-table
 ```
 
 ... or bin and write only the reads that are assigned to "group-3" or
 "group-4" by adding the '--groups group-3,group-4' flag
 ```
-mGEMS --groups group-3,group-4 -r reads_1.fastq.gz,reads_2.fastq.gz --themisto-alns pseudoalignments_1.aln.gz,pseudoalignments_2.aln.gz -o mGEMS-out --probs mSWEEP_probs.csv -a mSWEEP_abundances.txt --index themisto_index
+mGEMS --groups group-3,group-4 -r reads_1.fastq.gz,reads_2.fastq.gz -i reference_grouping.txt --themisto-alns pseudoalignments_1.aln.gz,pseudoalignments_2.aln.gz -o mGEMS-out --probs mSWEEP_probs.csv -a mSWEEP_abundances.txt --index themisto_index
 ```
 
 ... write the reads that pseudoaligned to a reference sequence but were not assigned to any group by adding the `--write-unassigned` flag:
 ```
-mGEMS --groups group-3,group-4 -r reads_1.fastq.gz,reads_2.fastq.gz --themisto-alns pseudoalignments_1.aln.gz,pseudoalignments_2.aln.gz -o mGEMS-out --probs mSWEEP_probs.csv -a mSWEEP_abundances.txt --index themisto_index --write-unassigned
+mGEMS --groups group-3,group-4 -r reads_1.fastq.gz,reads_2.fastq.gz -i reference_grouping.txt --themisto-alns pseudoalignments_1.aln.gz,pseudoalignments_2.aln.gz -o mGEMS-out --probs mSWEEP_probs.csv -a mSWEEP_abundances.txt --index themisto_index --write-unassigned
 ```
 
 Alternatively, find and write only the read bins for "group-3",
 "group-4", and the reads that pseudoaligned but were not assigned to
 any group; skipping extracting the reads
 ```
-mGEMS bin --groups group-3,group-4 --themisto-alns pseudoalignments_1.aln.gz,pseudoalignments_2.aln.gz -o mGEMS-out --probs mSWEEP_probs.csv -a mSWEEP_abundances.txt --index themisto_index --write-unassigned
+mGEMS bin --groups group-3,group-4 --themisto-alns pseudoalignments_1.aln.gz,pseudoalignments_2.aln.gz -i reference_grouping.txt -o mGEMS-out --probs mSWEEP_probs.csv -a mSWEEP_abundances.txt --index themisto_index --write-unassigned
 ```
 
 ... and extract the reads when feeling like it

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ To run the binning + assembly pipeline, you will need a program that
 does pseudoalignment and another program that estimates an assignment
 probability matrix for the reads to the alignment targets.
 
-*Note:* This version and the previous versions of mGEMS assume that
-you are using a Themisto version between v0.1.1 and v1.2.0. Update
+__Note:__ This version and the previous versions of mGEMS assume that
+you are using a *Themisto version between v0.1.1 and v1.2.0*. Update
 your mGEMS installation for compatibility with newer versions of
 Themisto.
 
 We recommend to use [Themisto](https://github.com/algbio/themisto)
-(versions between v0.1.1 or v1.2.0, update mGEMS for compatibility
+(*versions between v0.1.1 or v1.2.0*, update mGEMS for compatibility
 with newer versions) for pseudoalignment and
 [mSWEEP](https://github.com/probic/mSWEEP) (v1.3.2 or newer) for
 estimating the probability matrix. For assembling the bins output by
@@ -87,9 +87,11 @@ tree presented in Mäklin et al. 2020 using mGEMS is available in the
 [docs folder of this repository](docs/TUTORIAL.md).
 
 ### Quickstart — full pipeline
-*Themisto versions v0.1.1 to v1.2.0*
 Build a [Themisto](https://github.com/algbio/themisto) index to
 align against.
+
+__Themisto versions v0.1.1 to v1.2.0__
+
 ```
 mkdir themisto_index
 mkdir themisto_index/tmp
@@ -97,6 +99,9 @@ build_index --k 31 --input-file example.fasta --auto-colors --index-dir themisto
 ```
 
 Align paired-end reads 'reads_1.fastq.gz' and 'reads_2.fastq.gz' with Themisto (note the **--sort-output** flag must be used!)
+
+__Themisto versions v0.1.1 to v1.2.0__
+
 ```
 pseudoalign --index-dir themisto_index --query-file reads_1.fastq.gz --outfile pseudoalignments_1.aln --rc --temp-dir themisto_index/tmp --n-threads 16 --mem-megas 8192 --sort-output --gzip-output
 pseudoalign --index-dir themisto_index --query-file reads_2.fastq.gz --outfile pseudoalignments_2.aln --rc --temp-dir themisto_index/tmp --n-threads 16 --mem-megas 8192 --sort-output --gzip-output

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -11,9 +11,16 @@ For quick instructions on how to run the pipeline in a general
 setting, please refer to the README.md file in the root of this
 repository.
 
+*Note:* This version of the tutorial assumes that you are using a
+Themisto version between v0.1.1 and v1.2.0. Check the tutorial from an
+updated version of mGEMS for instructions on how to use newer versions
+of Themisto.
+
 ## Requirements
 ### mGEMS pipeline
 - [Themisto](https://github.com/algbio/Themisto)
+- - Themisto version should be between v0.1.1 and v1.2.0
+- - For compatibility with newer versions of Themisto, update your mGEMS installation.
 - [mSWEEP](https://github.com/probic/mSWEEP)
 - [mGEMS](https://github.com/probic/mGEMS)
 - [shovill](https://github.com/tseemann/shovill/)
@@ -85,6 +92,7 @@ tar -zxvf mGEMS-ecoli-reference-v1.0.0.tar.gz
 ```
 
 ### <a name="indexing"></a>Indexing
+*Themisto versions v0.1.1 to v1.2.0*
 Create a *31*-mer pseudoalignment index with Themisto using two
 threads and maximum 8192 megabytes of RAM.
 ```
@@ -119,6 +127,7 @@ gzip $oldid""_2.fastq
 ```
 
 ### <a name="pseudoalignment"></a>Pseudoalignment
+*Themisto versions v0.1.1 to v1.2.0*
 Align the mixed sample files against the index using two threads
 ```
 for f1 in *_1.fastq.gz; do

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -19,7 +19,7 @@ of Themisto.
 ## Requirements
 ### mGEMS pipeline
 - [Themisto](https://github.com/algbio/Themisto)
-- - Themisto version should be between v0.1.1 and v1.2.0
+- - Themisto version should be between *v0.1.1 and v1.2.0*
 - - For compatibility with newer versions of Themisto, update your mGEMS installation.
 - [mSWEEP](https://github.com/probic/mSWEEP)
 - [mGEMS](https://github.com/probic/mGEMS)
@@ -92,9 +92,11 @@ tar -zxvf mGEMS-ecoli-reference-v1.0.0.tar.gz
 ```
 
 ### <a name="indexing"></a>Indexing
-*Themisto versions v0.1.1 to v1.2.0*
 Create a *31*-mer pseudoalignment index with Themisto using two
 threads and maximum 8192 megabytes of RAM.
+
+__Themisto versions v0.1.1 to v1.2.0__
+
 ```
 mkdir mGEMS-ecoli-reference
 mkdir mGEMS-ecoli-reference/tmp
@@ -127,8 +129,10 @@ gzip $oldid""_2.fastq
 ```
 
 ### <a name="pseudoalignment"></a>Pseudoalignment
-*Themisto versions v0.1.1 to v1.2.0*
 Align the mixed sample files against the index using two threads
+
+__Themisto versions v0.1.1 to v1.2.0__
+
 ```
 for f1 in *_1.fastq.gz; do
 	f=${f1%_1.fastq.gz}

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -95,6 +95,14 @@ tar -zxvf mGEMS-ecoli-reference-v1.0.0.tar.gz
 Create a *31*-mer pseudoalignment index with Themisto using two
 threads and maximum 8192 megabytes of RAM.
 
+__Themisto version v2.0.0 or newer__
+
+```
+mkdir mGEMS-ecoli-reference
+mkdir mGEMS-ecoli-reference/tmp
+themisto build -k 31 -i mGEMS-ecoli-reference-sequences-v1.0.0.fasta.gz -o mGEMS-ecoli-reference/index --temp-dir mGEMS-ecoli-reference/tmp --mem-megas 8192 --n-threads 2
+```
+
 __Themisto versions v0.1.1 to v1.2.0__
 
 ```
@@ -131,6 +139,17 @@ gzip $oldid""_2.fastq
 ### <a name="pseudoalignment"></a>Pseudoalignment
 Align the mixed sample files against the index using two threads
 
+__Themisto version v2.0.0 or newer__
+
+```
+for f1 in *_1.fastq.gz; do
+	f=${f1%_1.fastq.gz}
+	f2=$f""_2.fastq.gz
+	themisto pseudoalign -q $f1 -o $f""_1.aln -i mGEMS-ecoli-reference/index --temp-dir mGEMS-ecoli-reference/tmp --n-threads 2 --rc --sort-output --gzip-output
+	themisto pseudoalign -q $f2 -o $f""_2.aln -i mGEMS-ecoli-reference/index --temp-dir mGEMS-ecoli-reference/tmp --n-threads 2 --rc --sort-output --gzip-output
+done
+```
+
 __Themisto versions v0.1.1 to v1.2.0__
 
 ```
@@ -160,7 +179,7 @@ Bin the reads with mGEMS and write the binned samples to the
 while read line; do
 	id=$(echo $line | cut -f3 -d' ')
 	cluster=$(echo $line | cut -f2 -d' ')
-	mGEMS --groups $cluster -r $id""_1.fastq.gz,$id""_2.fastq.gz --themisto-alns $id""_1.aln.gz,$id""_2.aln.gz -o $id --probs $id/$id""_probs.csv.gz -a $id/$id""_abundances.txt --index mGEMS-ecoli-reference
+	mGEMS --groups $cluster -r $id""_1.fastq.gz,$id""_2.fastq.gz -i mGEMS-ecoli-reference-grouping-v1.0.0.txt --themisto-alns $id""_1.aln.gz,$id""_2.aln.gz -o $id --probs $id/$id""_probs.csv.gz -a $id/$id""_abundances.txt --index mGEMS-ecoli-reference
 done < mixed_samples.tsv
 ```
 Note that by default mGEMS creates bins for **all** reference lineages. If know


### PR DESCRIPTION
Themisto's command line interface and index output format will change with the v2.0.0 release (see [Themisto 87ad71f8](https://github.com/algbio/themisto/tree/87ad71f8249b51442c0e99219002686c52f0676a)). This pull request adds the following changes for compatibility with both the new and the old versions:
- Added the `-i` argument for inputting the mSWEEP group indicators file to mGEMS so that the number of the reference sequences in the pseudoalignment  can be determined.
- If mGEMS can't find the Themisto <=v1.2.0 files in the `--themisto-index` directory **and** the `-i` argument is not supplied, the program will throw an error instructing the user to supply the `-i` argument.
- If the files are found, the `-i` argument is ignored and the program functions as it did previously.
- Updated documentation with usage instructions for both Themisto <=v1.2..0 and >=v2.0.0.

Please wait until the release of Themisto v2.0.0 before merging this pull request.